### PR TITLE
changed how students copy and past git config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ Let git know what your user name and email address are.
 
    ```bash
    git config --global user.name "[YOUR_NAME]"
+   ```
+   and then
+   ```bash
    git config --global user.email user@developersinstitute.co.nz
    ```
 


### PR DESCRIPTION
I noticed after helping Carlee that she instinctively went and copied both commands and pasted them into the terminal which would cause issues. 