### PR TITLE
restrict config file to github.com host and add new line

### DIFF
--- a/setup-ssh.sh
+++ b/setup-ssh.sh
@@ -39,10 +39,11 @@ eval "$(ssh-agent -s)"
 
 echo "Setting up ssh config file:"
 tee -a ~/.ssh/config << END
-Host *
+Host github.com
   AddKeysToAgent yes
   UseKeychain yes
   IdentityFile ${SSH_KEYFILE}
+  
 END
 
 ssh-add -K $SSH_KEYFILE


### PR DESCRIPTION
In its current state rerunning the shell script will cause a corrupt .ssh/config file as it prepends its new lines to whatever is already there.
We probably want to limit hosts to just github, and only alter this part of the file if it is present